### PR TITLE
Allow empty date string

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -46,6 +46,7 @@ function parseAmount (str) {
 }
 
 function formatDate (date) {
+  if (date === '') return date
   if (!(date instanceof Date)) error('Invalid date object')
   return `${pad(date.getDate() + '')}.${pad(date.getMonth() + 1 + '')}.${date.getFullYear()}`
 }


### PR DESCRIPTION
The UPNQR spec allows for empty dates.
Fixes #2.